### PR TITLE
Upgrade SpiderOakOne to 7.5.1.

### DIFF
--- a/spideroakone/spideroakone.nuspec
+++ b/spideroakone/spideroakone.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>7.5.0</version>
+    <version>7.5.1</version>
     <packageSourceUrl>https://github.com/mfschumann/chocolatey-packages/tree/master/spideroakone</packageSourceUrl>
 
     <owners>Martin F. Schumann</owners>
@@ -62,20 +62,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 </description>
     <releaseNotes>
     __UPSTREAM CHANGES:__
-     - Update icons for MacOS Volume
-     - New Backend Certificate
-     - Magellan security fix
-     - Inform user of account status in-app
-     - Disable translations if they are not in use.
-     - Force TLS1.2 method on every platform except macOS High Sierra
-     - Build macOS with PIE enabled
-     - Notify users when updates are available
-     - Improve overlay icons on Windows
-     
-    __UPSTREAM BUG FIXES:__
-     - Stability improvements for slow networks
-     - Fix regression on Share indicators being different colors than intended
-     - Fix manpage generation
+     - Added code signature to the main app binary
 </releaseNotes>
     <!-- =============================== -->      
 

--- a/spideroakone/tools/chocolateyinstall.ps1
+++ b/spideroakone/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName= 'spideroakone'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://spideroak.com/share/M5XWYZDFNY/retriever/c%3A/Fetch/SpiderOak%20One/7.5.0/SpiderOakONE-7.5.0-msi_x86.msi'
-$url64      = 'https://spideroak.com/share/M5XWYZDFNY/retriever/c%3A/Fetch/SpiderOak%20One/7.5.0/SpiderOakONE-7.5.0-msi_x64.msi'
+$url        = 'https://spideroak.com/release/spideroak/msi_x86'
+$url64      = 'https://spideroak.com/release/spideroak/msi_x64'
 
 $packageArgs = @{
   packageName   = $packageName
@@ -14,9 +14,9 @@ $packageArgs = @{
 
   softwareName  = 'SpiderOakONE*'
 
-  checksum      = 'a6cd33b797f2252dad20bbf158ca1b33ee378932faeea7fc0bc2461ace727580'
+  checksum      = '00e9ee18e133fa0298492f3dda7f8eaedd99d2a71adfe19fe606f0613d0ab4b5'
   checksumType  = 'sha256'
-  checksum64    = '510d51586448222e1c4ebd32b42edd6c0f8251a5e72778af911d85b30232e43f'
+  checksum64    = '59ef0dcc90265efd209e05887965d7587686556d88980dfa41fdcc9ae76e8bab'
   checksumType64= 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""


### PR DESCRIPTION
Could not find a stable download URL for this exact version, so used the generic https://spideroak.com/release/spideroak/msi_x64 URL.